### PR TITLE
fix(types): only augment module 'vue'

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,5 +1,5 @@
 import { ToastifyContainer, type ToastFunc } from 'vue3-toastify';
-import type { Plugin, VNode } from 'vue';
+import type { Plugin } from 'vue';
 
 declare const Vue3Toastify: Plugin;
 export default Vue3Toastify;
@@ -11,7 +11,7 @@ declare global {
   }
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $toast: ToastFunc;
   }


### PR DESCRIPTION
Augment Vue.js types instead of `@vue/runtime-core` to fix incompatibility with other libraries caused by the current augmentation behavior. For more information see https://github.com/nuxt/nuxt/pull/28542