### PR TITLE
fix: prevent conflict with tailwindcss @layer base

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -9,11 +9,12 @@ const Svg = ({ theme, type, path, ...rest }: BuiltInIconProps) =>
     viewBox="0 0 24 24"
     width="100%"
     height="100%"
-    fill={
-      theme === 'colored'
-        ? 'currentColor'
-        : `var(--toastify-icon-color-${type})`
-    }
+    style={{
+      fill:
+        theme === 'colored'
+          ? 'currentColor'
+          : `var(--toastify-icon-color-${type})`,
+    }}
     {...rest}
   >
     <path d={path} />


### PR DESCRIPTION
In my tailwindcss app.css, I have 
```
@layer base {
    svg { 
        fill: currentColor; 
    }
}
```
This should not be an issue, as everything in `@layer base` should have the lowest priority and inline style have the highest, but you use the fill `attribute` instead of the fill `property`.

Before:
<img width="682" height="935" alt="Screenshot 2025-08-19 at 11 45 47 AM" src="https://github.com/user-attachments/assets/cded11a1-b5f6-4d29-b540-4b1bb16516b4" />

After:
<img width="676" height="934" alt="Screenshot 2025-08-19 at 11 46 09 AM" src="https://github.com/user-attachments/assets/6b844246-6e46-47b6-896b-1766a9479ae7" />
